### PR TITLE
Add bower to the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "start": "brunch watch --server",
     "prod": "brunch build --production"
   },
-  "dependencies": {},
+  "dependencies": {
+    "bower": "^1.6.5"
+  },
   "devDependencies": {
     "brunch": "^2.10.5",
     "css-brunch": "^2.6.1",


### PR DESCRIPTION
To get the deploy in Bluemix to work correctly as per https://stackoverflow.com/questions/35205398/how-do-i-use-bower-to-manage-my-packages-with-bluemix.  Bower was not working unless I ran it locally and did a cf push from the public folder.